### PR TITLE
hardcaml-waveterm.0.2.2 - via opam-publish

### DIFF
--- a/packages/hardcaml-waveterm/hardcaml-waveterm.0.2.2/descr
+++ b/packages/hardcaml-waveterm/hardcaml-waveterm.0.2.2/descr
@@ -1,0 +1,1 @@
+Terminal based digital waveform viewer

--- a/packages/hardcaml-waveterm/hardcaml-waveterm.0.2.2/opam
+++ b/packages/hardcaml-waveterm/hardcaml-waveterm.0.2.2/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "andy.ray@ujamjar.com"
+authors: "andy.ray@ujamjar.com"
+homepage: "https://github.com/ujamjar/hardcaml-waveterm"
+bug-reports: "https://github.com/ujamjar/hardcaml-waveterm/issues"
+license: "ISC"
+dev-repo: "https://github.com/ujamjar/hardcaml-waveterm.git"
+substs: "pkg/META"
+build: ["ocaml" "pkg/pkg.ml" "build"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "hardcaml" {>= "1.2.0" & < "2.0.0"}
+  "astring"
+  "lambda-term"
+  "lwt" {>= "2.6.0"}
+]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/hardcaml-waveterm/hardcaml-waveterm.0.2.2/url
+++ b/packages/hardcaml-waveterm/hardcaml-waveterm.0.2.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ujamjar/hardcaml-waveterm/archive/v0.2.2.tar.gz"
+checksum: "b9563b0781f165c4a877e7772f4f4085"


### PR DESCRIPTION
Terminal based digital waveform viewer


---
* Homepage: https://github.com/ujamjar/hardcaml-waveterm
* Source repo: https://github.com/ujamjar/hardcaml-waveterm.git
* Bug tracker: https://github.com/ujamjar/hardcaml-waveterm/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.3