### PR TITLE
hardcaml.1.2.1 - via opam-publish

### DIFF
--- a/packages/hardcaml/hardcaml.1.2.1/descr
+++ b/packages/hardcaml/hardcaml.1.2.1/descr
@@ -1,0 +1,1 @@
+Register Transfer Level hardware design in OCaml

--- a/packages/hardcaml/hardcaml.1.2.1/opam
+++ b/packages/hardcaml/hardcaml.1.2.1/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+maintainer: "andy.ray@ujamjar.com"
+authors: "andy.ray@ujamjar.com"
+homepage: "https://github.com/ujamjar/hardcaml"
+bug-reports: "https://github.com/ujamjar/hardcaml/issues"
+license: "ISC"
+dev-repo: "https://github.com/ujamjar/hardcaml"
+substs: "pkg/META"
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--with-ctypes"
+  "%{ctypes:installed}%"
+  "--with-ctypes-foreign"
+  "%{ctypes-foreign:installed}%"
+  "--with-camlp4"
+  "%{camlp4:installed}%"
+  "--with-js_of_ocaml"
+  "%{js_of_ocaml:installed}%"
+  "--with-lwt"
+  "%{lwt:installed}%"
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "base-bytes"
+  "base-unix"
+  "astring"
+]
+depopts: ["camlp4" "ctypes" "ctypes-foreign" "js_of_ocaml" "lwt"]
+available: ["ocaml-version" >= "4.01.0"]

--- a/packages/hardcaml/hardcaml.1.2.1/url
+++ b/packages/hardcaml/hardcaml.1.2.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ujamjar/hardcaml/archive/v1.2.1.tar.gz"
+checksum: "caf8220e6ed72d7c3574c3965b769201"


### PR DESCRIPTION
Register Transfer Level hardware design in OCaml


---
* Homepage: https://github.com/ujamjar/hardcaml
* Source repo: https://github.com/ujamjar/hardcaml
* Bug tracker: https://github.com/ujamjar/hardcaml/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.3