### PR TITLE
hardcaml-framework.0.3.2 - via opam-publish

### DIFF
--- a/packages/hardcaml-framework/hardcaml-framework.0.3.2/descr
+++ b/packages/hardcaml-framework/hardcaml-framework.0.3.2/descr
@@ -1,0 +1,2 @@
+Framework for generating and simulating HardCaml cores 
+with console or javascript backends.

--- a/packages/hardcaml-framework/hardcaml-framework.0.3.2/opam
+++ b/packages/hardcaml-framework/hardcaml-framework.0.3.2/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "andy.ray@ujamjar.com"
+authors: "andy.ray@ujamjar.com"
+homepage: "https://github.com/ujamjar/hardcaml-framework"
+bug-reports: "https://github.com/ujamjar/hardcaml-framework/issues"
+license: "ISC"
+dev-repo: "https://github.com/ujamjar/hardcaml-framework.git"
+substs: "pkg/META"
+build: ["ocaml" "pkg/pkg.ml" "build"]
+depends: [
+  "hardcaml" {>= "1.2.0" & < "2.0.0"}
+  "ppx_deriving_hardcaml"
+  "hardcaml-waveterm" {>= "0.2.0"}
+  "astring"
+  "omd"
+  "lwt"
+  "js_of_ocaml"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/hardcaml-framework/hardcaml-framework.0.3.2/url
+++ b/packages/hardcaml-framework/hardcaml-framework.0.3.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ujamjar/hardcaml-framework/archive/v0.3.2.tar.gz"
+checksum: "9cb36cddf8b9168af1d86a81630a8a8b"


### PR DESCRIPTION
Framework for generating and simulating HardCaml cores 
with console or javascript backends.


---
* Homepage: https://github.com/ujamjar/hardcaml-framework
* Source repo: https://github.com/ujamjar/hardcaml-framework.git
* Bug tracker: https://github.com/ujamjar/hardcaml-framework/issues

---

Pull-request generated by opam-publish v0.3.3