### PR TITLE
hardcaml-examples.0.3.2 - via opam-publish

### DIFF
--- a/packages/hardcaml-examples/hardcaml-examples.0.3.2/descr
+++ b/packages/hardcaml-examples/hardcaml-examples.0.3.2/descr
@@ -1,0 +1,1 @@
+HardCaml examples designs build using hardcaml-framework

--- a/packages/hardcaml-examples/hardcaml-examples.0.3.2/opam
+++ b/packages/hardcaml-examples/hardcaml-examples.0.3.2/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "andy.ray@ujamjar.com"
+authors: "andy.ray@ujamjar.com"
+homepage: "https://github.com/ujamjar/hardcaml-examples"
+bug-reports: "https://github.com/ujamjar/hardcaml-examples/issues"
+license: "ISC"
+dev-repo: "https://github.com/ujamjar/hardcaml-examples.git"
+substs: "pkg/META"
+build: ["ocaml" "pkg/pkg.ml" "build"]
+depends: [
+  "hardcaml" {>= "1.2.0" & < "2.0.0"}
+  "hardcaml-waveterm"
+  "hardcaml-framework" {>= "0.3.0"}
+  "ppx_deriving_hardcaml" {>= "1.1.0"}
+  "astring"
+  "omd"
+  "lwt"
+  "js_of_ocaml"
+]
+available: [ocaml-version >= "4.01.0"]
+post-messages:
+  "
+You can use cohttp-server-lwt to try the example web-apps.
+
+$ cohttp-server-lwt `opam config var share`/hardcaml-examples
+  "

--- a/packages/hardcaml-examples/hardcaml-examples.0.3.2/url
+++ b/packages/hardcaml-examples/hardcaml-examples.0.3.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ujamjar/hardcaml-examples/archive/v0.3.2.tar.gz"
+checksum: "f4d117f5cab7bad4eec594e4f2ec5a38"


### PR DESCRIPTION
HardCaml examples designs build using hardcaml-framework


---
* Homepage: https://github.com/ujamjar/hardcaml-examples
* Source repo: https://github.com/ujamjar/hardcaml-examples.git
* Bug tracker: https://github.com/ujamjar/hardcaml-examples/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.3