### PR TITLE
hardcaml-llvmsim.0.3.2 - via opam-publish

### DIFF
--- a/packages/hardcaml-llvmsim/hardcaml-llvmsim.0.3.2/descr
+++ b/packages/hardcaml-llvmsim/hardcaml-llvmsim.0.3.2/descr
@@ -1,0 +1,1 @@
+HardCaml simulation backend using LLVM

--- a/packages/hardcaml-llvmsim/hardcaml-llvmsim.0.3.2/opam
+++ b/packages/hardcaml-llvmsim/hardcaml-llvmsim.0.3.2/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "andy.ray@ujamjar.com"
+authors: "andy.ray@ujamjar.com"
+homepage: "https://github.com/ujamjar/hardcaml-llvmsim"
+bug-reports: "https://github.com/ujamjar/hardcaml-llvmsim/issues"
+license: "ISC"
+dev-repo: "https://github.com/ujamjar/hardcaml-llvmsim.git"
+substs: "pkg/META"
+build: ["ocaml" "pkg/pkg.ml" "build"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "hardcaml" {>= "1.2.0" & < "2.0.0"}
+  "ctypes"
+  "ctypes-foreign"
+  "llvm" {>= "3.8"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/hardcaml-llvmsim/hardcaml-llvmsim.0.3.2/url
+++ b/packages/hardcaml-llvmsim/hardcaml-llvmsim.0.3.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ujamjar/hardcaml-llvmsim/archive/v0.3.2.tar.gz"
+checksum: "322f6b61cb1368486d90a7e824135bcf"


### PR DESCRIPTION
HardCaml simulation backend using LLVM


---
* Homepage: https://github.com/ujamjar/hardcaml-llvmsim
* Source repo: https://github.com/ujamjar/hardcaml-llvmsim.git
* Bug tracker: https://github.com/ujamjar/hardcaml-llvmsim/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.3