### PR TITLE
hardcaml-vpi.0.3.1 - via opam-publish

### DIFF
--- a/packages/hardcaml-vpi/hardcaml-vpi.0.3.1/descr
+++ b/packages/hardcaml-vpi/hardcaml-vpi.0.3.1/descr
@@ -1,0 +1,1 @@
+HardCaml Icarus Verilog cosimulation module

--- a/packages/hardcaml-vpi/hardcaml-vpi.0.3.1/opam
+++ b/packages/hardcaml-vpi/hardcaml-vpi.0.3.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "andy.ray@ujamjar.com"
+authors: "andy.ray@ujamjar.com"
+homepage: "https://github.com/ujamjar/hardcaml-vpi"
+bug-reports: "https://github.com/ujamjar/hardcaml-vpi/issues"
+license: "ISC"
+dev-repo: "https://github.com/ujamjar/hardcaml-vpi.git"
+substs: "pkg/META"
+build: [make "vpi"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ctypes"
+  "ctypes-foreign"
+  "hardcaml" {>= "1.2.0" & < "2.0.0"}
+]
+depexts: [
+  [["homebrew" "osx"] ["icarus-verilog"]]
+  [["ubuntu"] ["iverilog"]]
+]
+available: [os != "darwin" & ocaml-version >= "4.02.0"]

--- a/packages/hardcaml-vpi/hardcaml-vpi.0.3.1/url
+++ b/packages/hardcaml-vpi/hardcaml-vpi.0.3.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ujamjar/hardcaml-vpi/archive/v0.3.1.tar.gz"
+checksum: "b6e369345fc6791bc62aa87d256c3af1"


### PR DESCRIPTION
HardCaml Icarus Verilog cosimulation module


---
* Homepage: https://github.com/ujamjar/hardcaml-vpi
* Source repo: https://github.com/ujamjar/hardcaml-vpi.git
* Bug tracker: https://github.com/ujamjar/hardcaml-vpi/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.3