### PR TITLE
sattools.0.1.1 - via opam-publish

### DIFF
--- a/packages/sattools/sattools.0.1.1/descr
+++ b/packages/sattools/sattools.0.1.1/descr
@@ -1,0 +1,1 @@
+Ctypes and DIMACs interfaces to minisat, picosat and cryptominisat

--- a/packages/sattools/sattools.0.1.1/opam
+++ b/packages/sattools/sattools.0.1.1/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "andy.ray@ujamjar.com"
+authors: "andy.ray@ujamjar.com"
+homepage: "https://github.com/ujamjar/sattools"
+bug-reports: "https://github.com/ujamjar/sattools/issues"
+license: "ISC"
+dev-repo: "https://github.com/ujamjar/sattools.git"
+substs: "pkg/META"
+build: [make "build"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "base-bytes"
+  "base-unix"
+  "ctypes-foreign"
+  "ctypes"
+  "astring"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/sattools/sattools.0.1.1/url
+++ b/packages/sattools/sattools.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ujamjar/sattools/archive/v0.1.1.tar.gz"
+checksum: "74b4a304f83d2cf3213c03600cde6d1a"


### PR DESCRIPTION
Ctypes and DIMACs interfaces to minisat, picosat and cryptominisat


---
* Homepage: https://github.com/ujamjar/sattools
* Source repo: https://github.com/ujamjar/sattools.git
* Bug tracker: https://github.com/ujamjar/sattools/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.3