### PR TITLE
hardcaml-bloop.0.1.1 - via opam-publish

### DIFF
--- a/packages/hardcaml-bloop/hardcaml-bloop.0.1.1/descr
+++ b/packages/hardcaml-bloop/hardcaml-bloop.0.1.1/descr
@@ -1,0 +1,1 @@
+Boolean logic tools for HardCaml

--- a/packages/hardcaml-bloop/hardcaml-bloop.0.1.1/opam
+++ b/packages/hardcaml-bloop/hardcaml-bloop.0.1.1/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "andy.ray@ujamjar.com"
+authors: "andy.ray@ujamjar.com"
+homepage: "https://github.com/ujamjar/hardcaml-bloop"
+bug-reports: "https://github.com/ujamjar/hardcaml-bloop/issues"
+license: "ISC"
+dev-repo: "https://github.com/ujamjar/hardcaml-bloop.git"
+substs: "pkg/META"
+build: ["ocaml" "pkg/pkg.ml" "build"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "base-bytes"
+  "astring"
+  "hardcaml" {>= "1.2.0" & < "2.0.0"}
+  "sattools"
+  "bdd"
+  "uchar"
+  "uutf"
+  "gg"
+  "vg"
+]
+available: [ocaml-version >= "4.02.2"]

--- a/packages/hardcaml-bloop/hardcaml-bloop.0.1.1/url
+++ b/packages/hardcaml-bloop/hardcaml-bloop.0.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ujamjar/hardcaml-bloop/archive/v0.1.1.tar.gz"
+checksum: "0ad55474dc68b1ced6c309ac6bc439ab"


### PR DESCRIPTION
Boolean logic tools for HardCaml


---
* Homepage: https://github.com/ujamjar/hardcaml-bloop
* Source repo: https://github.com/ujamjar/hardcaml-bloop.git
* Bug tracker: https://github.com/ujamjar/hardcaml-bloop/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.3