### PR TITLE
hardcaml-affirm.0.1.2 - via opam-publish

### DIFF
--- a/packages/hardcaml-affirm/hardcaml-affirm.0.1.2/descr
+++ b/packages/hardcaml-affirm/hardcaml-affirm.0.1.2/descr
@@ -1,0 +1,1 @@
+Verification tools for HardCaml

--- a/packages/hardcaml-affirm/hardcaml-affirm.0.1.2/opam
+++ b/packages/hardcaml-affirm/hardcaml-affirm.0.1.2/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "andy.ray@ujamjar.com"
+authors: "andy.ray@ujamjar.com"
+homepage: "https://github.com/ujamjar/hardcaml-affirm"
+bug-reports: "https://github.com/ujamjar/hardcaml-affirm/issues"
+license: "ISC"
+dev-repo: "https://github.com/ujamjar/hardcaml-affirm.git"
+substs: "pkg/META"
+build: ["ocaml" "pkg/pkg.ml" "build"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "base-bytes"
+  "astring"
+  "hardcaml" {>= "1.2.0" & < "2.0.0"}
+  "sattools"
+  "hardcaml-bloop"
+  "hardcaml-waveterm" {>= "0.2"}
+  "ppx_deriving_hardcaml" {>= "1.1.0"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/hardcaml-affirm/hardcaml-affirm.0.1.2/url
+++ b/packages/hardcaml-affirm/hardcaml-affirm.0.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ujamjar/hardcaml-affirm/archive/v0.1.2.tar.gz"
+checksum: "2a17a93c71271ab5eacdf92dadd5d8b9"


### PR DESCRIPTION
Verification tools for HardCaml


---
* Homepage: https://github.com/ujamjar/hardcaml-affirm
* Source repo: https://github.com/ujamjar/hardcaml-affirm.git
* Bug tracker: https://github.com/ujamjar/hardcaml-affirm/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.3