### PR TITLE
hardcaml-yosys.0.1.2 - via opam-publish

### DIFF
--- a/packages/hardcaml-yosys/hardcaml-yosys.0.1.2/descr
+++ b/packages/hardcaml-yosys/hardcaml-yosys.0.1.2/descr
@@ -1,0 +1,1 @@
+Import Verilog designs into HardCaml

--- a/packages/hardcaml-yosys/hardcaml-yosys.0.1.2/opam
+++ b/packages/hardcaml-yosys/hardcaml-yosys.0.1.2/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Andy Ray <andy.ray@ujamjar.com>"
+authors: "Andy Ray"
+homepage: "https://github.com/ujamjar/hardcaml-yosys"
+bug-reports: "https://github.com/ujamjar/hardcaml-yosys/issues"
+license: "ISC"
+dev-repo: "https://github.com/ujamjar/hardcaml-yosys.git"
+build: ["ocaml" "pkg/pkg.ml" "build"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "atdgen"
+  "camlp4"
+  "hardcaml" {>= "1.2.0" & < "2.0.0"}
+  "ppx_hardcaml"
+  "ppx_deriving_hardcaml"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/hardcaml-yosys/hardcaml-yosys.0.1.2/url
+++ b/packages/hardcaml-yosys/hardcaml-yosys.0.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ujamjar/hardcaml-yosys/archive/v0.1.2.tar.gz"
+checksum: "12aee55642a2c0180ed195766dd2e010"


### PR DESCRIPTION
Import Verilog designs into HardCaml


---
* Homepage: https://github.com/ujamjar/hardcaml-yosys
* Source repo: https://github.com/ujamjar/hardcaml-yosys.git
* Bug tracker: https://github.com/ujamjar/hardcaml-yosys/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.3