### PR TITLE
hardcaml-vpi.0.3.2 - via opam-publish

### DIFF
--- a/packages/hardcaml-vpi/hardcaml-vpi.0.3.2/url
+++ b/packages/hardcaml-vpi/hardcaml-vpi.0.3.2/url
@@ -1,2 +1,2 @@
 http: "https://github.com/ujamjar/hardcaml-vpi/archive/v0.3.2.tar.gz"
-checksum: "b5b1f57b60799e16e9552f65e4258277"
+checksum: "d8e6870551169d5c7edac608bd9b0606"


### PR DESCRIPTION
HardCaml Icarus Verilog cosimulation module


---
* Homepage: https://github.com/ujamjar/hardcaml-vpi
* Source repo: https://github.com/ujamjar/hardcaml-vpi.git
* Bug tracker: https://github.com/ujamjar/hardcaml-vpi/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.3