### PR TITLE
sattools.0.1.1 - via opam-publish

### DIFF
--- a/packages/sattools/sattools.0.1.1/url
+++ b/packages/sattools/sattools.0.1.1/url
@@ -1,2 +1,2 @@
 http: "https://github.com/ujamjar/sattools/archive/v0.1.1.tar.gz"
-checksum: "74b4a304f83d2cf3213c03600cde6d1a"
+checksum: "8310901db092054eb1ca5aa02bd563bf"


### PR DESCRIPTION
Ctypes and DIMACs interfaces to minisat, picosat and cryptominisat


---
* Homepage: https://github.com/ujamjar/sattools
* Source repo: https://github.com/ujamjar/sattools.git
* Bug tracker: https://github.com/ujamjar/sattools/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.3