### PR TITLE
hardcaml-yosys.0.1.2 - via opam-publish

### DIFF
--- a/packages/hardcaml-yosys/hardcaml-yosys.0.1.2/url
+++ b/packages/hardcaml-yosys/hardcaml-yosys.0.1.2/url
@@ -1,2 +1,2 @@
 http: "https://github.com/ujamjar/hardcaml-yosys/archive/v0.1.2.tar.gz"
-checksum: "12aee55642a2c0180ed195766dd2e010"
+checksum: "2b1410e1da41780549d7397368f404e2"


### PR DESCRIPTION
Import Verilog designs into HardCaml


---
* Homepage: https://github.com/ujamjar/hardcaml-yosys
* Source repo: https://github.com/ujamjar/hardcaml-yosys.git
* Bug tracker: https://github.com/ujamjar/hardcaml-yosys/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.3