### PR TITLE
hardcaml-reedsolomon.0.3.2 - via opam-publish

### DIFF
--- a/packages/hardcaml-reedsolomon/hardcaml-reedsolomon.0.3.2/descr
+++ b/packages/hardcaml-reedsolomon/hardcaml-reedsolomon.0.3.2/descr
@@ -1,0 +1,1 @@
+HardCaml implementation of Reed-Solomon error correction coding

--- a/packages/hardcaml-reedsolomon/hardcaml-reedsolomon.0.3.2/opam
+++ b/packages/hardcaml-reedsolomon/hardcaml-reedsolomon.0.3.2/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "andy.ray@ujamjar.com"
+authors: "andy.ray@ujamjar.com"
+homepage: "https://github.com/ujamjar/hardcaml-reedsolomon"
+bug-reports: "https://github.com/ujamjar/hardcaml-reedsolomon/issues"
+license: "ISC"
+dev-repo: "https://github.com/ujamjar/hardcaml-reedsolomon.git"
+substs: "pkg/META"
+build: [make "all"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "hardcaml" {>= "1.2.0" & < "2.0.0"}
+  "hardcaml-waveterm" {>= "0.2.0"}
+  "hardcaml-framework" {>= "0.3.0"}
+  "ppx_deriving_hardcaml" {>= "1.1.0"}
+  "reedsolomon"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/hardcaml-reedsolomon/hardcaml-reedsolomon.0.3.2/url
+++ b/packages/hardcaml-reedsolomon/hardcaml-reedsolomon.0.3.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ujamjar/hardcaml-reedsolomon/archive/v0.3.2.tar.gz"
+checksum: "897a5965a11b908ae772bae0572ab941"


### PR DESCRIPTION
HardCaml implementation of Reed-Solomon error correction coding


---
* Homepage: https://github.com/ujamjar/hardcaml-reedsolomon
* Source repo: https://github.com/ujamjar/hardcaml-reedsolomon.git
* Bug tracker: https://github.com/ujamjar/hardcaml-reedsolomon/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.3