### PR TITLE
hardcaml-reedsolomon.0.3.3 - via opam-publish

### DIFF
--- a/packages/hardcaml-reedsolomon/hardcaml-reedsolomon.0.3.3/descr
+++ b/packages/hardcaml-reedsolomon/hardcaml-reedsolomon.0.3.3/descr
@@ -1,0 +1,1 @@
+HardCaml implementation of Reed-Solomon error correction coding

--- a/packages/hardcaml-reedsolomon/hardcaml-reedsolomon.0.3.3/opam
+++ b/packages/hardcaml-reedsolomon/hardcaml-reedsolomon.0.3.3/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "andy.ray@ujamjar.com"
+authors: "andy.ray@ujamjar.com"
+homepage: "https://github.com/ujamjar/hardcaml-reedsolomon"
+bug-reports: "https://github.com/ujamjar/hardcaml-reedsolomon/issues"
+license: "ISC"
+dev-repo: "https://github.com/ujamjar/hardcaml-reedsolomon.git"
+substs: "pkg/META"
+build: ["ocaml" "pkg/pkg.ml" "build"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "hardcaml" {>= "1.2.0" & < "2.0.0"}
+  "hardcaml-waveterm" {>= "0.2.0"}
+  "hardcaml-framework" {>= "0.3.0"}
+  "ppx_deriving_hardcaml" {>= "1.1.0"}
+  "reedsolomon"
+]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/hardcaml-reedsolomon/hardcaml-reedsolomon.0.3.3/url
+++ b/packages/hardcaml-reedsolomon/hardcaml-reedsolomon.0.3.3/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ujamjar/hardcaml-reedsolomon/archive/v0.3.3.tar.gz"
+checksum: "b468907caa191ab890901c0177368ec9"


### PR DESCRIPTION
HardCaml implementation of Reed-Solomon error correction coding


---
* Homepage: https://github.com/ujamjar/hardcaml-reedsolomon
* Source repo: https://github.com/ujamjar/hardcaml-reedsolomon.git
* Bug tracker: https://github.com/ujamjar/hardcaml-reedsolomon/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

Pull-request generated by opam-publish v0.3.3